### PR TITLE
android:allowBackup=false forces me to use tools:replace in my projec…

### DIFF
--- a/SpinnerDatePickerLib/src/main/AndroidManifest.xml
+++ b/SpinnerDatePickerLib/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
           package="com.tsongkha.spinnerdatepicker"
 >
 
-    <application android:allowBackup="true"
+    <application 
                  android:label="@string/app_name"
                  android:supportsRtl="true"
     >


### PR DESCRIPTION
…t manifest

I love this library, thanks so much!

Can you eliminate the allowsBackup property?  When this is set - I am required to add a tools attribute to my project AndroidManifest.xml (tools:replace="android:allowBackup" to my top-level).

I think this will make the library integration just a bit cleaner.  Thanks again, I had been looking for something like this (and am so surprised about the limitations and challenges of the native DatePicker).