### PR TITLE
Added options for hiding the title and the day of month picker

### DIFF
--- a/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/DatePicker.java
+++ b/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/DatePicker.java
@@ -83,7 +83,9 @@ public class DatePicker extends FrameLayout {
 
     private Calendar mCurrentDate;
 
+
     private boolean mIsEnabled = DEFAULT_ENABLED_STATE;
+    private boolean mIsDayEnabled = true;
 
     DatePicker(ViewGroup root, int numberPickerStyle) {
         super(root.getContext());
@@ -143,6 +145,7 @@ public class DatePicker extends FrameLayout {
         mDaySpinner.setOnValueChangedListener(onChangeListener);
         mDaySpinnerInput = NumberPickers.findEditText(mDaySpinner);
 
+
         // month
         mMonthSpinner = (NumberPicker) inflater.inflate(R.layout.number_picker_day_month,
                                                         mPickerContainer, false);
@@ -177,7 +180,8 @@ public class DatePicker extends FrameLayout {
     }
 
     void init(int year, int monthOfYear, int dayOfMonth,
-              OnDateChangedListener onDateChangedListener) {
+              boolean isDayEnabled, OnDateChangedListener onDateChangedListener) {
+        mIsDayEnabled = isDayEnabled;
         setDate(year, monthOfYear, dayOfMonth);
         updateSpinners();
         mOnDateChangedListener = onDateChangedListener;
@@ -380,6 +384,7 @@ public class DatePicker extends FrameLayout {
 
     private void updateSpinners() {
         // set the spinner ranges respecting the min and max dates
+        mDaySpinner.setVisibility(mIsDayEnabled ? View.VISIBLE : View.GONE);
         if (mCurrentDate.equals(mMinDate)) {
             mDaySpinner.setMinValue(mCurrentDate.get(Calendar.DAY_OF_MONTH));
             mDaySpinner.setMaxValue(mCurrentDate.getActualMaximum(Calendar.DAY_OF_MONTH));

--- a/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/DatePickerDialog.java
+++ b/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/DatePickerDialog.java
@@ -25,7 +25,9 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
     private final DatePicker mDatePicker;
     private final OnDateSetListener mCallBack;
     private final DateFormat mTitleDateFormat;
-    private boolean mIsDayEnabled;
+
+    private boolean mIsDayEnabled = true;
+    private boolean mUpdateTitleEnabled = true;
 
     /**
      * The callback used to indicate the user is done filling in the date.
@@ -48,12 +50,14 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
                      Calendar defaultDate,
                      Calendar minDate,
                      Calendar maxDate,
-                     boolean isDayEnabled) {
+                     boolean isDayEnabled,
+                     boolean updateTitleEnabled) {
         super(context, theme);
 
         mCallBack = callBack;
         mTitleDateFormat = DateFormat.getDateInstance(DateFormat.LONG);
         mIsDayEnabled = isDayEnabled;
+        mUpdateTitleEnabled = updateTitleEnabled;
 
         updateTitle(defaultDate);
 
@@ -69,7 +73,7 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
         mDatePicker = new DatePicker((ViewGroup) view, spinnerTheme);
         mDatePicker.setMinDate(minDate.getTimeInMillis());
         mDatePicker.setMaxDate(maxDate.getTimeInMillis());
-        mDatePicker.init(defaultDate.get(Calendar.YEAR), defaultDate.get(Calendar.MONTH), defaultDate.get(Calendar.DAY_OF_MONTH), mIsDayEnabled, this);
+        mDatePicker.init(defaultDate.get(Calendar.YEAR), defaultDate.get(Calendar.MONTH), defaultDate.get(Calendar.DAY_OF_MONTH), isDayEnabled, this);
 
     }
 
@@ -92,8 +96,12 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
     }
 
     private void updateTitle(Calendar updatedDate) {
-        final DateFormat dateFormat = mTitleDateFormat;
-        setTitle(dateFormat.format(updatedDate.getTime()));
+        if(mUpdateTitleEnabled) {
+            final DateFormat dateFormat = mTitleDateFormat;
+            setTitle(dateFormat.format(updatedDate.getTime()));
+        } else {
+            setTitle(" ");
+        }
     }
 
     @Override

--- a/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/DatePickerDialog.java
+++ b/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/DatePickerDialog.java
@@ -25,6 +25,7 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
     private final DatePicker mDatePicker;
     private final OnDateSetListener mCallBack;
     private final DateFormat mTitleDateFormat;
+    private boolean mIsDayEnabled;
 
     /**
      * The callback used to indicate the user is done filling in the date.
@@ -46,11 +47,13 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
                      OnDateSetListener callBack,
                      Calendar defaultDate,
                      Calendar minDate,
-                     Calendar maxDate) {
+                     Calendar maxDate,
+                     boolean isDayEnabled) {
         super(context, theme);
 
         mCallBack = callBack;
         mTitleDateFormat = DateFormat.getDateInstance(DateFormat.LONG);
+        mIsDayEnabled = isDayEnabled;
 
         updateTitle(defaultDate);
 
@@ -66,7 +69,7 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
         mDatePicker = new DatePicker((ViewGroup) view, spinnerTheme);
         mDatePicker.setMinDate(minDate.getTimeInMillis());
         mDatePicker.setMaxDate(maxDate.getTimeInMillis());
-        mDatePicker.init(defaultDate.get(Calendar.YEAR), defaultDate.get(Calendar.MONTH), defaultDate.get(Calendar.DAY_OF_MONTH), this);
+        mDatePicker.init(defaultDate.get(Calendar.YEAR), defaultDate.get(Calendar.MONTH), defaultDate.get(Calendar.DAY_OF_MONTH), mIsDayEnabled, this);
 
     }
 
@@ -113,6 +116,6 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
         c.set(Calendar.MONTH, month);
         c.set(Calendar.DAY_OF_MONTH, day);
         updateTitle(c);
-        mDatePicker.init(year, month, day, this);
+        mDatePicker.init(year, month, day, mIsDayEnabled, this);
     }
 }

--- a/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/SpinnerDatePickerDialogBuilder.java
+++ b/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/SpinnerDatePickerDialogBuilder.java
@@ -10,6 +10,7 @@ public class SpinnerDatePickerDialogBuilder {
     private Context context;
     private DatePickerDialog.OnDateSetListener callBack;
     private boolean isYearOptional = false;
+    private boolean isDayEnabled = true;
     private int theme = -1;                 //default theme
     private int spinnerTheme = -1;          //default theme
     private Calendar defaultDate = new GregorianCalendar(1980, 0, 1);
@@ -52,10 +53,15 @@ public class SpinnerDatePickerDialogBuilder {
         return this;
     }
 
+    public SpinnerDatePickerDialogBuilder dayEnabled(boolean isDayEnabled) {
+        this.isDayEnabled = isDayEnabled;
+        return this;
+    }
+
     public DatePickerDialog build() {
         if (context == null) throw new IllegalArgumentException("Context must not be null");
         if (maxDate.getTime().getTime() <= minDate.getTime().getTime()) throw new IllegalArgumentException("Max date is not after Min date");
 
-        return new DatePickerDialog(context, theme, spinnerTheme, callBack, defaultDate, minDate, maxDate);
+        return new DatePickerDialog(context, theme, spinnerTheme, callBack, defaultDate, minDate, maxDate, isDayEnabled);
     }
 }

--- a/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/SpinnerDatePickerDialogBuilder.java
+++ b/SpinnerDatePickerLib/src/main/java/com/tsongkha/spinnerdatepicker/SpinnerDatePickerDialogBuilder.java
@@ -11,6 +11,7 @@ public class SpinnerDatePickerDialogBuilder {
     private DatePickerDialog.OnDateSetListener callBack;
     private boolean isYearOptional = false;
     private boolean isDayEnabled = true;
+    private boolean updateTitleEnabled = true;
     private int theme = -1;                 //default theme
     private int spinnerTheme = -1;          //default theme
     private Calendar defaultDate = new GregorianCalendar(1980, 0, 1);
@@ -58,10 +59,15 @@ public class SpinnerDatePickerDialogBuilder {
         return this;
     }
 
+    public SpinnerDatePickerDialogBuilder updateTitleEnabled(boolean updateTitleEnabled) {
+        this.updateTitleEnabled = updateTitleEnabled;
+        return this;
+    }
+
     public DatePickerDialog build() {
         if (context == null) throw new IllegalArgumentException("Context must not be null");
         if (maxDate.getTime().getTime() <= minDate.getTime().getTime()) throw new IllegalArgumentException("Max date is not after Min date");
 
-        return new DatePickerDialog(context, theme, spinnerTheme, callBack, defaultDate, minDate, maxDate, isDayEnabled);
+        return new DatePickerDialog(context, theme, spinnerTheme, callBack, defaultDate, minDate, maxDate, isDayEnabled, updateTitleEnabled);
     }
 }


### PR DESCRIPTION
Hi, great lib, it was exactly what I needed, so thanks a lot. 

I had a requirement, though, to create a spinner date picker without the day of month field and without a title, similar to the picker used in the LinkedIn Android app for the user to be able to specify their tenure at a company. I added these options to the Builder class. 