### PR TITLE
Remove android:label to simplify implementation

### DIFF
--- a/SpinnerDatePickerLib/src/main/AndroidManifest.xml
+++ b/SpinnerDatePickerLib/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 >
 
     <application 
-                 android:label="@string/app_name"
+                 
                  android:supportsRtl="true"
     >
 


### PR DESCRIPTION
Currently, I have to add an attribute to my Android.xml file (in my app) to use this lib, if you remove this attribute, I won't have to.  

Android Studio tells me what to add, so it is pretty simple, but it would be better if I didn't have to add it.

I must add:

<application
        ...
        tools:ignore="UnusedAttribute"